### PR TITLE
Fix typo in compilation error message

### DIFF
--- a/src/librustc_parse/parser/attr.rs
+++ b/src/librustc_parse/parser/attr.rs
@@ -135,7 +135,7 @@ impl<'a> Parser<'a> {
 
                         if let Some(prev_attr_sp) = prev_attr_sp {
                             diagnostic
-                                .span_label(attr_sp, "not permitted following an outer attibute")
+                                .span_label(attr_sp, "not permitted following an outer attribute")
                                 .span_label(prev_attr_sp, prev_attr_note);
                         }
 

--- a/src/test/ui/parser/inner-attr-after-doc-comment.stderr
+++ b/src/test/ui/parser/inner-attr-after-doc-comment.stderr
@@ -7,7 +7,7 @@ LL | |  */
    | |___- previous doc comment
 LL | 
 LL |   #![recursion_limit="100"]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^ not permitted following an outer attibute
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^ not permitted following an outer attribute
    |
    = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
 

--- a/src/test/ui/parser/inner-attr.stderr
+++ b/src/test/ui/parser/inner-attr.stderr
@@ -5,7 +5,7 @@ LL | #[feature(lang_items)]
    | ---------------------- previous outer attribute
 LL | 
 LL | #![recursion_limit="100"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ not permitted following an outer attibute
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ not permitted following an outer attribute
    |
    = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
 


### PR DESCRIPTION
*Current:*

```
.. | #![allow(dead_code)]
   | ^^^^^^^^^^^^^^^^^^^^ not permitted following an outer attibute
```

s/attibute/attribute/